### PR TITLE
LIBFCREPO-1157. Code review.

### DIFF
--- a/docs/add_handles.md
+++ b/docs/add_handles.md
@@ -1,4 +1,4 @@
-# add_handles
+# add-handles
 
 Handles script for oaipmh
 
@@ -9,7 +9,7 @@ that don't have it. Specifically it takes in the results from the plastron
 export command, and creates a new csv file with the handles column so the items
 can be updated.
 
-## Developtment Environment
+## Development Environment
 
 Same as in [README.md]
 
@@ -21,16 +21,17 @@ Same as in [README.md]
 
 Create a `handle_conf.yml` file with the following contents:
 
-```yml
-# Domain for the handles server
+```yaml
+# Endpoint for the handles server
+# (e.g., http://localhost:3000/api/v1)
 HANDLE_URL:
 # The base URL for the items
-# (ex: http://fcrepo-local:8080/fcrepo/rest/)
+# (e.g., http://fcrepo-local:8080/fcrepo/rest/)
 BASE_URL:
 # The public URL for where the items are in the frontend
-# (ex: https://digital.lib.umd.edu/result/id/)
+# (e.g., https://digital.lib.umd.edu/result/id/)
 PUBLIC_BASE_URL:
-# The JWT authenatication token generated from fcrepo
+# The JWT authentication token generated from fcrepo
 AUTH:
 
 ```
@@ -38,13 +39,14 @@ AUTH:
 ### Running
 
 ```zsh
-❯ add_handles -h
-Usage: add_handles [OPTIONS]
+$ add-handles -h
+Usage: add-handles [OPTIONS]
 
 Options:
-  -f, --file FILENAME         The export file to take in and add handles to.
-                              [required]
-  -o, --output FILENAME       Output for the handles, will default to stdout.
+  -i, --input-file FILENAME   The CSV export file to take in and add handles
+                              to. Defaults to STDIN.
+  -o, --output-file FILENAME  Output file for CSV file with handles. Defaults
+                              to STDOUT.
   -c, --config-file FILENAME  Config file to use for interacting with UMD-
                               Handle and Fcrepo  [required]
   -V, --version               Show the version and exit.
@@ -55,4 +57,4 @@ Options:
 
 Same as in [README.md]
 
-[README.md]: README.md
+[README.md]: ../README.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,3 +20,4 @@ test = [
 ]
 [project.scripts]
 fcrepo-oaipmh-server = "oaipmh.server:run"
+add-handles = "oaipmh.add_handles:main"

--- a/src/oaipmh/add_handles.py
+++ b/src/oaipmh/add_handles.py
@@ -90,7 +90,7 @@ def extract_from_url(fcrepo_path: str) -> tuple[str, str]:
 
 
 def mint_handle(config: dict, **json) -> str:
-    endpoint = '/api/v1/handles'
+    endpoint = '/handles'
     headers = {'Authorization': f'Bearer {config["AUTH"]}'}
     response = requests.post(config['HANDLE_URL'] + endpoint, json=json, headers=headers)
 

--- a/src/oaipmh/add_handles.py
+++ b/src/oaipmh/add_handles.py
@@ -1,3 +1,4 @@
+import logging
 import click
 import requests
 import sys
@@ -8,6 +9,7 @@ from csv import DictReader, DictWriter
 from oaipmh import __version__
 from typing import TextIO
 
+logger = logging.getLogger(__name__)
 
 
 class RequestFailure(Exception):
@@ -47,8 +49,8 @@ def main(input_file: TextIO, output_file: TextIO, config_file: TextIO):
         writer.writeheader()
         for row in exports:
             writer.writerow(row)
-    except Exception as e:
-        print(f'{type(e).__name__}: {str(e)}', file=sys.stderr)
+    except RequestFailure as e:
+        logger.error(str(e))
 
 
 def create_handles(reader: DictReader, config: dict) -> list:

--- a/src/oaipmh/add_handles.py
+++ b/src/oaipmh/add_handles.py
@@ -43,8 +43,12 @@ def main(input_file: TextIO, output_file: TextIO, config_file: TextIO):
         reader = DictReader(input_file)
         exports = create_handles(reader, config)
 
+        # ensure that there is a Handle header in the output file
+        fieldnames = list(reader.fieldnames)
+        if 'Handle' not in fieldnames:
+            fieldnames.append('Handle')
+
         # Write out to file or stdout
-        fieldnames = reader.fieldnames + ['Handle']
         writer = DictWriter(output_file, fieldnames=fieldnames)
         writer.writeheader()
         for row in exports:

--- a/src/oaipmh/add_handles.py
+++ b/src/oaipmh/add_handles.py
@@ -9,12 +9,9 @@ from oaipmh import __version__
 from typing import TextIO
 
 
-class RequestFailure(Exception):
-    def __init__(self, message):
-        self.message = message
 
-    def __str__(self):
-        return self.message
+class RequestFailure(Exception):
+    pass
 
 
 @click.command()

--- a/src/oaipmh/add_handles.py
+++ b/src/oaipmh/add_handles.py
@@ -16,14 +16,14 @@ class RequestFailure(Exception):
 
 @click.command()
 @click.option(
-    '--file', '-f',
-    help='The export file to take in and add handles to.',
+    '--input-file', '-i',
+    help='The CSV export file to take in and add handles to. Defaults to STDIN.',
+    default=sys.stdin,
     type=click.File(),
-    required=True
 )
 @click.option(
-    '--output', '-o',
-    help='Output for the handles, will default to stdout.',
+    '--output-file', '-o',
+    help='Output file for CSV file with handles. Defaults to STDOUT.',
     default=sys.stdout,
     type=click.File(mode='w'),
 )
@@ -35,15 +35,15 @@ class RequestFailure(Exception):
 )
 @click.version_option(__version__, '--version', '-V')
 @click.help_option('--help', '-h')
-def main(file: TextIO, output: TextIO, config_file: TextIO):
+def main(input_file: TextIO, output_file: TextIO, config_file: TextIO):
     try:
         config = yaml.safe_load(config_file)
-        reader = DictReader(file, delimiter=',')
+        reader = DictReader(input_file)
         exports = create_handles(reader, config)
 
         # Write out to file or stdout
         fieldnames = reader.fieldnames + ['Handle']
-        writer = DictWriter(output, fieldnames=fieldnames)
+        writer = DictWriter(output_file, fieldnames=fieldnames)
         writer.writeheader()
         for row in exports:
             writer.writerow(row)

--- a/src/oaipmh/add_handles.py
+++ b/src/oaipmh/add_handles.py
@@ -1,14 +1,14 @@
 import logging
 import re
+import sys
+from csv import DictReader, DictWriter
+from typing import TextIO
+
 import click
 import requests
-import sys
-import uuid
 import yaml
 
-from csv import DictReader, DictWriter
 from oaipmh import __version__
-from typing import TextIO
 
 logger = logging.getLogger(__name__)
 

--- a/tests/handles/test_handles.py
+++ b/tests/handles/test_handles.py
@@ -1,28 +1,24 @@
 import pytest
 
-from oaipmh.add_handles import extract_from_url
+from oaipmh.add_handles import extract_from_path
 
 
 @pytest.mark.parametrize(
-    ('fcrepo_path'),
+    ('fcrepo_path', 'expected_relpath', 'expected_uuid'),
     [
-        'dc/2021/2/27/fb/47/4e/27fb474e-4fef-43f7-bb57-18577a6ab944',
-        'dc/2021/2/8a/7f/e2/ef/8a7fe2ef-fdb1-4c2c-8199-6fe276d908e4',
-        'dc/2021/2/a3/53/da/54/a353da54-0401-41a1-bd40-0264d0d40661',
-        'dc/2021/2/06/db/6b/11/06db6b11-3be3-4710-9bbf-ba3a751dd633',
-        'dc/2021/2/78/f8/fb/9b/78f8fb9b-ce67-403f-9226-a22dda4f3085',
-        'dc/2021/2/ed/15/1c/12/ed151c12-2615-4dc1-8691-510b64d17ea0',
-        'dc/2021/2/a8/90/3c/d8/a8903cd8-8b85-4e29-9e99-d659e2627b53',
-        'dc/2021/2/ff/24/18/ba/ff2418ba-8ea1-4eb1-a177-a56f626e290f',
-        'dc/2021/2/f4/e7/83/28/f4e78328-265d-4708-a5dd-5da3385b0055',
-        'dc/2021/2/4e/27/03/ac/4e2703ac-2c8e-4982-bade-94c88e213b51',
-        'dc/2021/2/c8/9f/ae/bb/c89faebb-2709-4e8d-9975-e90510d39a98'
+        (
+            'dc/2021/2/27/fb/47/4e/27fb474e-4fef-43f7-bb57-18577a6ab944',
+            'dc/2021/2',
+            '27fb474e-4fef-43f7-bb57-18577a6ab944',
+        ),
+        (
+            'pcdm/8a/7f/e2/ef/8a7fe2ef-fdb1-4c2c-8199-6fe276d908e4',
+            'pcdm',
+            '8a7fe2ef-fdb1-4c2c-8199-6fe276d908e4',
+        ),
     ]
 )
-def test_extract(fcrepo_path):
-    correct_relpath = 'dc/2021/2'
-    correct_uuid = fcrepo_path.split('/')[-1]
-
-    relpath, uuid = extract_from_url(fcrepo_path)
-    assert relpath == correct_relpath
-    assert uuid == correct_uuid
+def test_extract(fcrepo_path, expected_relpath, expected_uuid):
+    relpath, uuid = extract_from_path(fcrepo_path)
+    assert relpath == expected_relpath
+    assert uuid == expected_uuid


### PR DESCRIPTION
- Sorted import statements.
- Moved and updated add_handles documentation.
- Switch to a regex based method for extracting the UUID and relpath.
- Renamed extract_from_url to extract_from_path since it deals with paths and not URLs.
- Only add the "Handle" header if there is none in the input file.
- Catch the more specific exception RequestFailure.
- Use logger instead of just printing the error to STDERR.
- Assume that the entire handle API endpoint (including the "/api/v1") is in the HANDLE_URL config value.
- Aligned all option names as "--{something}-file".
- Default the input file to STDIN.
- RequestFailure exception can just inherit from Exception with no custom methods.
- Added a "add-handles" script endpoint for the "add_handles.py" command.

https://issues.umd.edu/browse/LIBFCREPO-1157