### PR TITLE
LIBAVALON-305. Code review.

### DIFF
--- a/src/oaipmh/dataprovider.py
+++ b/src/oaipmh/dataprovider.py
@@ -29,7 +29,7 @@ class DataProvider(DataInterface):
     oai_repository_name = EnvAttribute('OAI_REPOSITORY_NAME')
     oai_namespace_identifier = EnvAttribute('OAI_NAMESPACE_IDENTIFIER')
     report_deleted_records = EnvAttribute('REPORT_DELETED_RECORDS', 'no')
-    handle_proxy_prefix = EnvAttribute('HANDLE_PROXY_PREFIX')
+    handle_proxy_prefix = EnvAttribute('HANDLE_PROXY_PREFIX', '')
     limit: int = EnvAttribute('PAGE_SIZE', 25)
 
     def __init__(self, index: Index):
@@ -46,7 +46,7 @@ class DataProvider(DataInterface):
         """
         return OAIIdentifier(
             namespace_identifier=self.oai_namespace_identifier,
-            local_identifier=handle,
+            local_identifier=handle.replace(self.handle_proxy_prefix, ''),
         )
 
     def get_uri(self, identifier: str) -> str:

--- a/src/oaipmh/dataprovider.py
+++ b/src/oaipmh/dataprovider.py
@@ -149,9 +149,6 @@ class DataProvider(DataInterface):
         identifiers = [str(self.get_oai_identifier(self.index.get_handle(doc))) for doc in results]
         return identifiers, results.hits, None
 
-    def get_record_metadata(self, identifier: str, metadataprefix: str) -> _Element | None:
-        raise NotImplementedError
-
 
 class FedoraDataProvider(DataProvider):
     def __init__(self, index: Index):

--- a/src/oaipmh/dataprovider.py
+++ b/src/oaipmh/dataprovider.py
@@ -149,6 +149,9 @@ class DataProvider(DataInterface):
         identifiers = [str(self.get_oai_identifier(self.index.get_handle(doc))) for doc in results]
         return identifiers, results.hits, None
 
+    def get_record_metadata(self, identifier: str, metadataprefix: str) -> _Element | None:
+        raise NotImplementedError
+
 
 class FedoraDataProvider(DataProvider):
     def __init__(self, index: Index):

--- a/src/oaipmh/dataprovider.py
+++ b/src/oaipmh/dataprovider.py
@@ -180,7 +180,20 @@ class AvalonDataProvider(DataProvider):
     def __init__(self, index: Index):
         super().__init__(index)
 
+    def get_metadata_formats(self, identifier: str | None = None) -> list[MetadataFormat]:
+        return [
+            MetadataFormat(
+                metadata_prefix='oai_dc',
+                metadata_namespace='http://www.openarchives.org/OAI/2.0/oai_dc/',
+                schema='http://www.openarchives.org/OAI/2.0/oai_dc.xsd',
+            )
+        ]
+
     def get_record_metadata(self, identifier: str, metadataprefix: str) -> _Element | None:
+        if metadataprefix != 'oai_dc':
+            # only oai_dc is supported for Avalon
+            raise OAIErrorCannotDisseminateFormat
+
         uri = self.get_uri(identifier)
         response = self.session.get(self.avalon_public_url + uri + '.json')
         if response.ok:


### PR DESCRIPTION
- use only the handle string as the OAI local identifier; remove the handle proxy prefix
- restrict the Avalon data provider to only the `oai_dc` metadata prefix
- provided a stub "not implemented" `get_record_metadata()` method in the `DataProvider` base class

https://umd-dit.atlassian.net/browse/LIBAVALON-305